### PR TITLE
cmake: fix the build on aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions -funroll-loops -march=native")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions -funroll-loops -march=native -fsigned-char")
   if(CMAKE_BUILD_TYPE MATCHES "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
   endif()


### PR DESCRIPTION
x86 platforms generally use a default-signed char, but !x86 does not necessarily.  Force it with -fsiged-char so that all platforms assume the correct signedness, which fixes the build on aarch64 at the very least.

This is a nop on x86, so we don't bother trying to scope it beyond GCC/Clang.