### PR TITLE
Fix bug with calculating seed table for negated dungeon seeds

### DIFF
--- a/tools/seed_table.cpp
+++ b/tools/seed_table.cpp
@@ -174,7 +174,7 @@ struct GameState {
 		}
 		startingSeed = backtrackRng(state);
 
-		state = seed;
+		state = useNegatedState ? -static_cast<int32_t>(seed) : seed;
 		for (int i = level + 1; i < seedTable.size(); ++i) {
 			state = advanceRng(state);
 			seedTable[i] = std::abs(static_cast<int32_t>(state));


### PR DESCRIPTION
The latter half of the table generated from a dungeon seed wasn't correct for the negated case