### PR TITLE
Add verbose option to sort_candidates and short description to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,9 @@ These terms clarify the different types of seeds used in Diablo MapGen and provi
 - **Game Seed:** The time() value set on game creation. It serves as the initial seed for generating dungeon seeds and determines the overall characteristics of a game session.
 - **Dungeon Seed:** The floor-specific seed saved to the seed table. This seed determines the placement of monsters and items within each floor of the dungeon. The dungeon seed is derived from the game seed at the beginning of the game session.
 - **Level Seed:** This is the value that generates the specific layout of tiles for a given level in the dungeon. The level seed is derived by starting with the dungeon seed and then letting the RNG advance each time the level generator does not produce a valid level.
+
+## Additional tools
+
+`seed_table` shows what dungeon seeds correspond to a given game seed and when that game occurred (as game seeds are a unix timestamp representing the local date/time), or show what game seeds lead to a given dungeon seed. This allows expanding an ideal dungeon seed into a complete dungeon table to evaluate the overall run.
+
+`sort_candidates` is mainly intended for analysis, if you have a list of dungeon seeds and you want to find out which ones occurred in games started near a certain point of time you can use this tool to sort by proximity to a unix timestamp.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,6 @@ These terms clarify the different types of seeds used in Diablo MapGen and provi
 
 ## Additional tools
 
-`seed_table` shows what dungeon seeds correspond to a given game seed and when that game occurred (as game seeds are a unix timestamp representing the local date/time), or show what game seeds lead to a given dungeon seed. This allows expanding an ideal dungeon seed into a complete dungeon table to evaluate the overall run.
+`seed_table` shows what dungeon seeds correspond to a given game seed and when that game occurred (as game seeds are a unix timestamp representing the UTC date/time), or show what game seeds lead to a given dungeon seed. This allows expanding an ideal dungeon seed into a complete dungeon table to evaluate the overall run.
 
 `sort_candidates` is mainly intended for analysis, if you have a list of dungeon seeds and you want to find out which ones occurred in games started near a certain point of time you can use this tool to sort by proximity to a unix timestamp.

--- a/tools/sort_candidates.cpp
+++ b/tools/sort_candidates.cpp
@@ -14,7 +14,7 @@
 
 static void showUsage(std::string_view programName)
 {
-	std::cerr << "Usage: " << programName << " <target_timestamp> <level> seeds.txt\n";
+	std::cerr << "Usage: " << programName << " <target_timestamp> <level> seeds.txt [--verbose]\n";
 }
 
 template <typename resultType, typename intermediateType>
@@ -71,6 +71,23 @@ static int32_t absShiftMod(uint32_t state, int32_t limit)
 	return (seed >> 16) % limit;
 }
 
+static uint32_t absDelta(uint32_t a, uint32_t b)
+{
+	return static_cast<uint32_t>(abs(static_cast<int64_t>(a) - b));
+}
+
+static auto formatDate(uint32_t timestamp)
+{
+	time_t time = std::chrono::system_clock::to_time_t(std::chrono::time_point<std::chrono::system_clock>(std::chrono::seconds(timestamp)));
+	return std::put_time(std::gmtime(&time), "%Y-%m-%d %H:%M:%S");
+}
+
+struct SeedMap {
+	uint32_t dungeonSeed;
+	uint32_t gameSeed;
+	std::optional<uint32_t> altGameSeed {};
+};
+
 int main(int argc, char *argv[])
 {
 	if (argc < 4) {
@@ -100,7 +117,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	std::map<uint32_t, std::vector<uint32_t>> seedsByDelta {};
+	std::map<uint32_t, std::vector<SeedMap>> seedsByDelta {};
 
 	for (std::string line; std::getline(seedsFile, line);) {
 		std::optional<uint32_t> seed = parseSeed(line);
@@ -115,30 +132,40 @@ int main(int argc, char *argv[])
 		}
 		uint32_t startingSeed = backtrackRng(state);
 
-		uint32_t delta = static_cast<uint32_t>(abs(static_cast<int64_t>(*targetTimestamp) - startingSeed));
+		uint32_t delta = absDelta(*targetTimestamp, startingSeed);
 
 		if (*seed <= std::numeric_limits<int32_t>::max()) {
 			state = -static_cast<int32_t>(*seed);
 			for (int i = *level - 1; i >= 0; --i) {
 				state = backtrackRng(state);
 			}
-			startingSeed = backtrackRng(state);
+			uint32_t negStartingSeed = backtrackRng(state);
 
-			delta = std::min(delta, static_cast<uint32_t>(abs(static_cast<int64_t>(*targetTimestamp) - startingSeed)));
-		}
+			uint32_t negDelta = absDelta(*targetTimestamp, startingSeed);
 
-		if (seedsByDelta.contains(delta)) {
-			seedsByDelta[delta].push_back(*seed);
+			if (negDelta < delta) {
+				seedsByDelta[negDelta].emplace_back(*seed, negStartingSeed, startingSeed);
+			} else {
+				seedsByDelta[delta].emplace_back(*seed, startingSeed, negStartingSeed);
+			}
+		} else {
+			seedsByDelta[delta].emplace_back(*seed, startingSeed);
 		}
-		else {
-			seedsByDelta.emplace(delta, std::vector { *seed });
-		}
-
 	}
+
+	using namespace std::literals;
+	bool verbose = (argc >= 4 && "--verbose"sv == argv[4]);
 
 	for (auto &[_, seeds] : seedsByDelta) {
 		for (auto seed : seeds) {
-			std::cout << seed << "\n";
+			std::cout << seed.dungeonSeed;
+			if (verbose) {
+				std::cout << "\t" << seed.gameSeed << "\t" << formatDate(seed.gameSeed);
+				if (seed.altGameSeed) {
+					std::cout << "\t" << *seed.altGameSeed << "\t" << formatDate(*seed.altGameSeed);
+				}
+			}
+			std::cout << "\n";
 		}
 	}
 

--- a/tools/sort_candidates.cpp
+++ b/tools/sort_candidates.cpp
@@ -27,6 +27,7 @@ std::optional<resultType> parseNumber(std::string_view numericString, intermedia
 			return static_cast<resultType>(value);
 		}
 		// else fall through
+		[[fallthrough]];
 	case std::errc::result_out_of_range:
 		std::cerr << numericString << " is outside the expected range of " << minValue << " to " << maxValue << ".\n";
 		break;
@@ -128,7 +129,7 @@ int main(int argc, char *argv[])
 
 		uint32_t state = *seed;
 		for (int i = *level - 1; i >= 0; --i) {
-			state        = backtrackRng(state);
+			state = backtrackRng(state);
 		}
 		uint32_t startingSeed = backtrackRng(state);
 
@@ -157,7 +158,7 @@ int main(int argc, char *argv[])
 	bool verbose = (argc >= 4 && "--verbose"sv == argv[4]);
 
 	for (auto &[_, seeds] : seedsByDelta) {
-		for (auto seed : seeds) {
+		for (auto &seed : seeds) {
 			std::cout << seed.dungeonSeed;
 			if (verbose) {
 				std::cout << "\t" << seed.gameSeed << "\t" << formatDate(seed.gameSeed);


### PR DESCRIPTION
I found the verbose output useful to show which dungeon seeds were valid and shortcut having to look up the game seed/time in the seed_table tool