### PR TITLE
Add clangd idx file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,3 +384,6 @@ levels/
 ddraw_settings.ini
 /build*
 .codelite
+
+# clangd
+*.idx


### PR DESCRIPTION
When I use VSCode/VSCodium alongside the clangd extension, hundreds of index files are generated with the `idx` extension. This change will tell git to ignore those files.