### PR TITLE
Move Scanner name code to separate file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(${BIN_TARGET}
   Source/analyzer/pattern.cpp
   Source/analyzer/puzzler.cpp
   Source/analyzer/quest.cpp
+  Source/analyzer/scannerName.cpp
   Source/analyzer/stairs.cpp
   Source/analyzer/warp.cpp
   Source/funkMapGen.cpp

--- a/Source/analyzer/scannerName.cpp
+++ b/Source/analyzer/scannerName.cpp
@@ -1,0 +1,83 @@
+#include "scannerName.h"
+
+#include <cstdlib>
+#include <algorithm>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+std::optional<Scanners> Scanners_FromDisplayName(std::string_view name)
+{
+	// For any new scanners, just add to the pre-sorted lookup table.
+	constexpr std::pair<std::string_view, Scanners> displayNames[] = {
+		{ "gameseed", Scanners::GameSeed },
+		{ "none", Scanners::None },
+		{ "path", Scanners::Path },
+		{ "pattern", Scanners::Pattern },
+		{ "puzzler", Scanners::Puzzler },
+		{ "quest", Scanners::Quest },
+		{ "stairs", Scanners::Stairs },
+		{ "warp", Scanners::Warp },
+	};
+	static_assert(
+		std::is_sorted(
+			std::cbegin(displayNames), std::cend(displayNames)));
+
+	std::pair key = std::make_pair(name, Scanners::None);
+	auto result =
+		std::equal_range(
+			std::cbegin(displayNames),
+			std::cend(displayNames),
+			key,
+			[](auto& lhs, auto& rhs) {
+				return lhs.first < rhs.first;
+			});
+	if (result.first == std::cend(displayNames)) {
+		return std::nullopt;
+	}
+
+	return result.first->second;
+}
+
+std::optional<std::string> Scanners_ToDisplayName(Scanners scanner)
+{
+	switch (scanner) {
+		case Scanners::None: {
+			static constexpr std::string_view displayName = "none";
+			return std::string(displayName);
+		}
+		case Scanners::Path: {
+			static constexpr std::string_view displayName = "path";
+			return std::string(displayName);
+		}
+		case Scanners::Quest: {
+			static constexpr std::string_view displayName = "quest";
+			return std::string(displayName);
+		}
+		case Scanners::Puzzler: {
+			static constexpr std::string_view displayName = "puzzler";
+			return std::string(displayName);
+		}
+		case Scanners::Stairs: {
+			static constexpr std::string_view displayName = "stairs";
+			return std::string(displayName);
+		}
+		case Scanners::Warp: {
+			static constexpr std::string_view displayName = "warp";
+			return std::string(displayName);
+		}
+		case Scanners::Pattern: {
+			static constexpr std::string_view displayName = "pattern";
+			return std::string(displayName);
+		}
+		case Scanners::GameSeed: {
+			static constexpr std::string_view displayName = "gameseed";
+			return std::string(displayName);
+		}
+		default: {
+			return std::nullopt;
+		}
+	}
+}

--- a/Source/analyzer/scannerName.h
+++ b/Source/analyzer/scannerName.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+enum class Scanners {
+	None,
+	Path,
+	Quest,
+	Puzzler,
+	Stairs,
+	Warp,
+	Pattern,
+	GameSeed,
+};
+
+std::optional<Scanners> Scanners_FromDisplayName(std::string_view name);
+std::optional<std::string> Scanners_ToDisplayName(Scanners scanner);

--- a/Source/funkMapGen.cpp
+++ b/Source/funkMapGen.cpp
@@ -6,6 +6,8 @@
 #include <limits>
 #include <optional>
 #include <sstream>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "analyzer/gameseed.h"
@@ -13,6 +15,7 @@
 #include "analyzer/pattern.h"
 #include "analyzer/puzzler.h"
 #include "analyzer/quest.h"
+#include "analyzer/scannerName.h"
 #include "analyzer/stairs.h"
 #include "analyzer/warp.h"
 #include "drlg_l1.h"
@@ -321,27 +324,13 @@ void ParseArguments(int argc, char **argv)
 				std::cerr << "Missing value for --scanner" << std::endl;
 				exit(255);
 			}
-			std::string scanner = argv[i];
-			if (scanner == "none") {
-				Config.scanner = Scanners::None;
-			} else if (scanner == "puzzler") {
-				Config.scanner = Scanners::Puzzler;
-			} else if (scanner == "path") {
-				Config.scanner = Scanners::Path;
-			} else if (scanner == "quest") {
-				Config.scanner = Scanners::Quest;
-			} else if (scanner == "warp") {
-				Config.scanner = Scanners::Warp;
-			} else if (scanner == "stairs") {
-				Config.scanner = Scanners::Stairs;
-			} else if (scanner == "pattern") {
-				Config.scanner = Scanners::Pattern;
-			} else if (scanner == "gameseed") {
-				Config.scanner = Scanners::GameSeed;
-			} else {
-				std::cerr << "Unknown scanner: " << scanner << std::endl;
+			std::string_view name = argv[i];
+			std::optional<Scanners> scanner = Scanners_FromDisplayName(name);
+			if (!scanner.has_value()) {
+				std::cerr << "Unknown scanner: " << name << std::endl;
 				exit(255);
 			}
+			Config.scanner = *scanner;
 		} else if (arg == "--seeds") {
 			i++;
 			if (argc <= i) {

--- a/Source/funkMapGen.h
+++ b/Source/funkMapGen.h
@@ -3,17 +3,7 @@
 #include <string>
 
 #include "engine.h"
-
-enum class Scanners {
-	None,
-	Path,
-	Quest,
-	Puzzler,
-	Stairs,
-	Warp,
-	Pattern,
-	GameSeed,
-};
+#include "analyzer/scannerName.h"
 
 struct Configuration {
 	uint32_t startSeed = 0;


### PR DESCRIPTION
Scanner name parsing is moved to a separate file, in addition to putting all of the scanner values in a lookup table.