### PR TITLE
Fix sources for monster desync on dlvls 15 and 16

### DIFF
--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1301,9 +1301,9 @@ BYTE *lpSetPiece4;
 void DRLG_PreLoadDiabQuads()
 {
 	lpSetPiece1 = LoadFileInMem("Levels\\L4Data\\diab1.DUN", NULL);
-	lpSetPiece2 = LoadFileInMem("Levels\\L4Data\\diab2b.DUN", NULL);
-	lpSetPiece3 = LoadFileInMem("Levels\\L4Data\\diab3b.DUN", NULL);
-	lpSetPiece4 = LoadFileInMem("Levels\\L4Data\\diab4b.DUN", NULL);
+	lpSetPiece2 = LoadFileInMem("Levels\\L4Data\\diab2a.DUN", NULL);
+	lpSetPiece3 = LoadFileInMem("Levels\\L4Data\\diab3a.DUN", NULL);
+	lpSetPiece4 = LoadFileInMem("Levels\\L4Data\\diab4a.DUN", NULL);
 }
 
 void DRLG_FreeDiabQuads()

--- a/Source/funkMapGen.cpp
+++ b/Source/funkMapGen.cpp
@@ -181,6 +181,9 @@ std::optional<uint32_t> CreateDungeon(DungeonMode mode)
 		if (mode != DungeonMode::NoContent && mode != DungeonMode::BreakOnFailureOrNoContent)
 			CreateDungeonContent();
 
+		if (leveltype == DTYPE_HELL)
+			InitL4PentagramTriggers();
+
 		if (currlevel == 15) {
 			// Locate Lazarus warp point
 			Point point = { quests[Q_BETRAYER]._qtx, quests[Q_BETRAYER]._qty };

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -237,6 +237,17 @@ void InitL4Triggers()
 				trigs[numtrigs]._tmsg = WM_DIABNEXTLVL;
 				numtrigs++;
 			}
+		}
+	}
+	trigflag = FALSE;
+}
+
+void InitL4PentagramTriggers()
+{
+	int i, j;
+
+	for (j = 0; j < MAXDUNY; j++) {
+		for (i = 0; i < MAXDUNX; i++) {
 			if (dPiece[i][j] == 336 || dPiece[i][j] == 370) {
 				trigs[numtrigs]._tx = i;
 				trigs[numtrigs]._ty = j;
@@ -245,7 +256,6 @@ void InitL4Triggers()
 			}
 		}
 	}
-	trigflag = FALSE;
 }
 
 void InitSKingTriggers()

--- a/Source/trigs.h
+++ b/Source/trigs.h
@@ -18,6 +18,7 @@ void InitL1Triggers();
 void InitL2Triggers();
 void InitL3Triggers();
 void InitL4Triggers();
+void InitL4PentagramTriggers();
 void InitSKingTriggers();
 void InitSChambTriggers();
 void InitPWaterTriggers();


### PR DESCRIPTION
* `InitMonsters()` uses the number of triggers to set up vision radius around the stairs so it can avoid placing monsters near them.
* `Freeupstairs()` was reserving space around the triggers for stair placement where it shouldn't have been.
* The open rooms on dlvl 16 have fewer solid tiles than the closed rooms, which affects the number of monsters the game attempts to place on the map.
* We shouldn't be placing monsters in the non-solid tiles of open rooms on dlvl 16 if the same tiles are solid in the closed rooms.

All the points above were causing RNG desync for monsters on dlvls 15 and 16. This PR uses the closed rooms on dlvl 16 and delays the initialization of the pentagram triggers until after monster generation.