### PR TITLE
Use more descriptive output for seed table tool

### DIFF
--- a/tools/seed_table.cpp
+++ b/tools/seed_table.cpp
@@ -209,14 +209,17 @@ struct GameState {
 static void renderSeedTable(const GameState &state)
 {
 	time_t startingTime = std::chrono::system_clock::to_time_t(std::chrono::time_point<std::chrono::system_clock>(std::chrono::seconds(state.startingSeed)));
-	std::cout << "Game seed: " << state.startingSeed << " (" << std::put_time(std::gmtime(&startingTime), "%Y-%m-%d %H:%M:%S");
-	if (315532800 <= state.startingSeed && state.startingSeed <= 2177452799U) {
-		std::cout << " can be reached by setting the system time)\n";
+	std::cout << "Game seed: " << state.startingSeed << " (" << std::put_time(std::gmtime(&startingTime), "%Y-%m-%d %H:%M:%S") << " ";
+	if (state.startingSeed == -1) {
+		std::cout << "is the default game seed before 1970/after 2038";
+	} else if (315532800 <= state.startingSeed && state.startingSeed <= 2177452799U) {
+		std::cout << "can be reached by setting the system time";
 	} else if (state.startingSeed < 315532800) {
-		std::cout << " requires an NT based Windows and an old BIOS or using the Mac version)\n";
+		std::cout << "requires an NT based Windows and an old BIOS or using the Mac version";
 	} else {
-		std::cout << " requires a modern recompile)\n";
+		std::cout << "requires a modern recompile";
 	}
+	std::cout << ")\n";
 
 	Quests activeQuests = determineActiveQuests(state.seedTable[15]);
 


### PR DESCRIPTION
Calling out the -1 game seed and adding the underlying representation to the output to help illustrate the difference between positive and "negative" dungeon seeds.